### PR TITLE
feat: Add custom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Delete all listed buffers except the current one (add `!` to ignore changes):
 You can pass options to the `setup()` function. Here are the default options:
 ```lua
 require('bufdel').setup {
-  next = 'tabs',  -- or 'cycle, 'alternate'
-  quit = true,    -- quit Neovim when last buffer is closed
+  next = 'tabs',
+  quit = true,  -- quit Neovim when last buffer is closed
 }
 ```
 
@@ -76,3 +76,4 @@ Supported values:
   one.
 * `alternate`: switch to the alternate buffer (same behavior as without the
   plugin).
+* You can also pass your own function to select the next buffer.

--- a/lua/bufdel.lua
+++ b/lua/bufdel.lua
@@ -6,7 +6,7 @@
 local M = {}
 local options = {
   next = 'tabs',  -- how to retrieve the next buffer
-  quit = true,    -- exit when last buffer is deleted
+  quit = true,    -- quit Neovim when last buffer is closed
 }
 
 -------------------- PRIVATE -------------------------------
@@ -26,6 +26,10 @@ local function get_next_buf(buf)
   local alternate = vim.fn.bufnr('#')
   if options.next == 'alternate' and vim.fn.buflisted(alternate) == 1 then
     return alternate
+  end
+  -- handle custom function
+  if type(options.next) == 'function' then
+    return options.next()
   end
   -- build table mapping buffers to their actual position
   local buffers, buf_index = {}, 1


### PR DESCRIPTION
Hello, this is the feature that I talked about in #7.
I hope this feature is useful for others than me.

This commit introduces a new mode called 'custom'. It can be used to supply a custom function to choose the next buffer to switch after the current buffer was closed.

Closes #7.